### PR TITLE
Trigger a build exception if v0 quiz syntax is detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ content:
 ```
 <!-- prettier-ignore-end -->
 
-**New Syntax (v2.0):**
+**New Syntax (v1.0):**
 
 ```markdown
 <quiz>

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -4,6 +4,8 @@ title: Updating
 
 # Migration from Old Syntax
 
+The v1 rewrite of mkdocs-quiz changed the syntax used for writing quiz questions.
+
 If you have quizzes using the old pre-v1 mkdocs-quiz syntax (`question:`, `answer-correct:`, etc.), you can use the migration CLI tool to update your docs:
 
 ```bash


### PR DESCRIPTION
The old quiz syntax is no longer supported, so the v1 release will cause unprocessed v0 quiz syntax to go through to the HTML page.

That's confusing for maintainers who probably won't have noticed the version change, if it's unpinned.

This PR adds a check for the old syntax that triggers a build error with an explanation. This will cause automated builds to fail and also tell people why, and how to fix it:

```
ValueError: ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
###########  ERROR: Old mkdocs-quiz syntax detected: old_quiz.md
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Quiz syntax used by mkdocs-quiz changed in the v1 release!
Please use the CLI migration tool to update your quizzes:

    mkdocs-quiz migrate docs/

Read more: https://ewels.github.io/mkdocs-quiz/updating/
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

<details><summary>Full output</summary>

```
❯ mkdocs serve
INFO    -  Building documentation...
INFO    -  Cleaning site directory
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
             - old_quiz.md
WARNING -  Doc file 'contributing.md' contains a link '.github/workflows/publish.yml', but the target is not found among documentation
           files.
ERROR   -  Error reading page 'old_quiz.md': ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
           ###########  ERROR: Old mkdocs-quiz syntax detected: old_quiz.md
           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

           Quiz syntax used by mkdocs-quiz changed in the v1 release!
           Please use the CLI migration tool to update your quizzes:

               mkdocs-quiz migrate docs/

           Read more: https://ewels.github.io/mkdocs-quiz/updating/
           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Traceback (most recent call last):
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/lib/python3.12/site-packages/click/core.py", line 1462, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/lib/python3.12/site-packages/click/core.py", line 1383, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/lib/python3.12/site-packages/click/core.py", line 1850, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/lib/python3.12/site-packages/click/core.py", line 1246, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/lib/python3.12/site-packages/click/core.py", line 814, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/lib/python3.12/site-packages/mkdocs/__main__.py", line 272, in serve_command
    serve.serve(**kwargs)
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/lib/python3.12/site-packages/mkdocs/commands/serve.py", line 85, in serve
    builder(config)
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/lib/python3.12/site-packages/mkdocs/commands/serve.py", line 67, in builder
    build(config, serve_url=None if is_clean else serve_url, dirty=is_dirty)
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/lib/python3.12/site-packages/mkdocs/commands/build.py", line 310, in build
    _populate_page(file.page, config, files, dirty)
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/lib/python3.12/site-packages/mkdocs/commands/build.py", line 163, in _populate_page
    page.markdown = config.plugins.on_page_markdown(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/lib/python3.12/site-packages/mkdocs/plugins.py", line 635, in on_page_markdown
    return self.run_event('page_markdown', markdown, page=page, config=config, files=files)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.12/lib/python3.12/site-packages/mkdocs/plugins.py", line 566, in run_event
    result = method(item, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ewels/GitHub/ewels/mkdocs-quiz/mkdocs_quiz/plugin.py", line 448, in on_page_markdown
    self._check_for_old_syntax(masked_markdown, page)
  File "/Users/ewels/GitHub/ewels/mkdocs-quiz/mkdocs_quiz/plugin.py", line 408, in _check_for_old_syntax
    raise ValueError(error_msg)
ValueError: ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
###########  ERROR: Old mkdocs-quiz syntax detected: old_quiz.md
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Quiz syntax used by mkdocs-quiz changed in the v1 release!
Please use the CLI migration tool to update your quizzes:

    mkdocs-quiz migrate docs/

Read more: https://ewels.github.io/mkdocs-quiz/updating/
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

</details>

I figure it's better to break explicitly and help folks, rather than break silently and wait for users to discover the error on people's websites.