### PR TITLE
Fix plugin name in documentation (issue #11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ The [quiz.js](mkdocs_quiz/js/quiz.js) file:
 
 ```yaml
 plugins:
-  - mkdocs-quiz:
+  - mkdocs_quiz:
       enabled_by_default: true # Process quizzes by default (default: true)
       auto_number: false # Auto-number questions (default: false)
       show_correct: true # Show correct answers when wrong (default: true)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add the plugin to your `mkdocs.yml`:
 
 ```yaml
 plugins:
-  - mkdocs-quiz
+  - mkdocs_quiz
 ```
 
 ### 2. Add your first question

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ The mkdocs-quiz plugin can be configured both at plugin-wide level or page-level
 
     ```yaml
     plugins:
-      - mkdocs-quiz
+      - mkdocs_quiz
     ```
 
 The full plugin-wide options in `mkdocs.yml` with their default values are as follows:
@@ -19,7 +19,7 @@ The full plugin-wide options in `mkdocs.yml` with their default values are as fo
 <!-- prettier-ignore-start -->
 ```yaml title="mkdocs.yml"
 plugins:
-  - mkdocs-quiz:
+  - mkdocs_quiz:
       enabled_by_default: true        # Enable quizzes by default on all pages
       auto_number: false              # Auto-number questions (Question 1:, Question 2:, etc.)
       show_correct: true              # Show correct answers when user gets it wrong

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,7 +47,7 @@ Add the plugin to your `mkdocs.yml` configuration file:
 
 ```yaml
 plugins:
-  - mkdocs-quiz
+  - mkdocs_quiz
 ```
 
 That's it! The plugin is now active and will process all quiz blocks in your markdown files.

--- a/docs/results-screen.md
+++ b/docs/results-screen.md
@@ -46,7 +46,7 @@ The confetti animation is enabled by default but can be disabled in your `mkdocs
 
 ```yaml
 plugins:
-  - mkdocs-quiz:
+  - mkdocs_quiz:
       confetti: false
 ```
 


### PR DESCRIPTION
Update all configuration examples to use the correct plugin name
'mkdocs_quiz' (with underscore) instead of the incorrect 'mkdocs-quiz'
(with hyphen). The hyphen syntax does not work and was misleading users.

Fixes #11