### PR TITLE
Revise French translations in fr.po file

### DIFF
--- a/mkdocs_quiz/locales/fr.po
+++ b/mkdocs_quiz/locales/fr.po
@@ -5,7 +5,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/ewels/mkdocs-quiz/issues\n"
 "POT-Creation-Date: 2025-11-27 22:12+0100\n"
 "PO-Revision-Date: 2025-11-30 07:45+0000\n"
-"Last-Translator: Claude <noreply@anthropic.com>\n"
+"Last-Translator: @maxulysse\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -59,15 +59,15 @@ msgstr "Excellent travail ! Vous maîtrisez vraiment le sujet !"
 
 #: js/quiz.js:340
 msgid "Good effort! Keep learning!"
-msgstr "Bon effort ! Continuez à apprendre !"
+msgstr "Bien joué ! Continuez à apprendre !"
 
 #: js/quiz.js:343
 msgid "Not bad, but there's room for improvement!"
-msgstr "Pas mal, mais il y a de la place pour s'améliorer !"
+msgstr "Pas mal, mais peut mieux faire !"
 
 #: js/quiz.js:346
 msgid "Better luck next time! Keep trying!"
-msgstr "Plus de chance la prochaine fois ! Continuez d'essayer !"
+msgstr "Ça sera mieux la prochaine fois ! Continuez d'essayer !"
 
 #: js/quiz.js:462
 msgid ""


### PR DESCRIPTION
Updated initial Claude made French translations by a native speaker.

Really minor updates on the French side, to make it less directly translated from English, Claude actually did a pretty good job.
And it even put spaces before some punctuation symbols, which is the actual rule, but all French are slowly transitioning towards a more global standard. (And I would have used a small space instead of a regular one if I'm really being picky).