### PR TITLE
Pin GitHub Actions to latest major versions with SHA hashes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Dereference symlinks and convert to lowercase
       - name: Dereference symlinks and ensure lowercase
@@ -30,12 +30,12 @@ jobs:
           cp CHANGELOG.md docs/changelog.md
           cp CONTRIBUTING.md docs/contributing.md
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.x
 
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
@@ -47,7 +47,7 @@ jobs:
       - run: mkdocs build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./site
 
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ jobs:
       id-token: write # Required for trusted publishing
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 
@@ -35,6 +35,6 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           print-hash: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -35,7 +35,7 @@ jobs:
           ruff format --check mkdocs_quiz tests
 
       - name: Check formatting with prettier
-        uses: actionsx/prettier@v3
+        uses: actionsx/prettier@3d9f7c3fa44c9cb819e68292a328d7f4384be206 # v3
         with:
           args: --check "mkdocs_quiz/**/*.{js,css}"
 
@@ -53,14 +53,14 @@ jobs:
           pytest tests/ -v --cov=mkdocs_quiz --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         if: matrix.python-version == '3.11'
         with:
           file: ./coverage.xml
           fail_ci_if_error: false
 
       - name: Upload screenshots on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: failure()
         with:
           name: playwright-screenshots-${{ matrix.python-version }}
@@ -72,10 +72,10 @@ jobs:
   test-wheel-install:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary
- Update all GitHub Actions to their latest major versions to resolve Node.js 20 deprecation warnings
- Pin every action by full commit SHA for supply chain security, with version comments for readability

### Actions updated

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v4 | v6.0.2 |
| `actions/setup-python` | v5 | v6.2.0 |
| `actions/cache` | v4 | v5.0.4 |
| `actions/upload-pages-artifact` | v3 | v4.0.0 |
| `actions/deploy-pages` | v4 | v5.0.0 |
| `actions/upload-artifact` | v4 | v7.0.0 |
| `codecov/codecov-action` | v4 | v6.0.0 |
| `pypa/gh-action-pypi-publish` | v1 | v1.14.0 (pinned, already latest) |
| `actionsx/prettier` | v3 | v3 (pinned, already latest) |

## Test plan
- [ ] Verify all three workflows run successfully (test, deploy-docs, publish)
- [ ] Confirm Node.js 20 deprecation warnings are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)