### PR TITLE
Fix pymdownx.snippets auto_append leaking into quiz fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- Fix `pymdownx.snippets` `auto_append` files (e.g. an abbreviations glossary) leaking into every quiz question and answer - [#56](https://github.com/ewels/mkdocs-quiz/issues/56)
+
 ## **Version 1.6.4** (2026-05-06)
 
 ### Bug Fixes

--- a/mkdocs_quiz/plugin.py
+++ b/mkdocs_quiz/plugin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import fnmatch
 import html
 import json
@@ -789,9 +790,21 @@ class MkDocsQuizPlugin(BasePlugin):
         The returned instance can be reused across fragments by calling `.reset()`
         between conversions.
         """
+        # Each quiz part (question, answers, content) is converted as its own
+        # mini-document. `pymdownx.snippets`' `auto_append` injects file content
+        # into every document the Markdown instance processes, which would
+        # duplicate the appended snippet (e.g. an abbreviations file) into every
+        # single fragment and leak its raw contents into the output (see #56).
+        # Strip `auto_append` for fragment conversion.
+        extension_configs = config.mdx_configs or {}
+        snippets_config = extension_configs.get("pymdownx.snippets")
+        if isinstance(snippets_config, dict) and "auto_append" in snippets_config:
+            extension_configs = copy.deepcopy(extension_configs)
+            extension_configs["pymdownx.snippets"].pop("auto_append", None)
+
         md_inst = md.Markdown(
             extensions=config.markdown_extensions,
-            extension_configs=config.mdx_configs or {},
+            extension_configs=extension_configs,
         )
 
         # Register MkDocs-specific processors used during full page rendering

--- a/mkdocs_quiz/plugin.py
+++ b/mkdocs_quiz/plugin.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 import fnmatch
 import html
 import json
@@ -795,12 +794,17 @@ class MkDocsQuizPlugin(BasePlugin):
         # into every document the Markdown instance processes, which would
         # duplicate the appended snippet (e.g. an abbreviations file) into every
         # single fragment and leak its raw contents into the output (see #56).
-        # Strip `auto_append` for fragment conversion.
+        # Strip `auto_append` for fragment conversion, without mutating the
+        # shared `config.mdx_configs`.
         extension_configs = config.mdx_configs or {}
         snippets_config = extension_configs.get("pymdownx.snippets")
         if isinstance(snippets_config, dict) and "auto_append" in snippets_config:
-            extension_configs = copy.deepcopy(extension_configs)
-            extension_configs["pymdownx.snippets"].pop("auto_append", None)
+            extension_configs = {
+                **extension_configs,
+                "pymdownx.snippets": {
+                    k: v for k, v in snippets_config.items() if k != "auto_append"
+                },
+            }
 
         md_inst = md.Markdown(
             extensions=config.markdown_extensions,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1637,6 +1637,61 @@ def test_markdown_extensions_with_config_options(
     assert "<h2" in html_result
 
 
+def test_snippets_auto_append_not_injected_into_fragments(
+    plugin: MkDocsQuizPlugin,
+    mock_page: Page,
+    mock_config: MkDocsConfig,
+    mock_files: Files,
+    tmp_path,
+) -> None:
+    """Regression test for #56.
+
+    `pymdownx.snippets` `auto_append` injects file content into every document
+    the Markdown instance processes. Since each quiz part (question, answers,
+    content) is converted as its own fragment, the appended file (e.g. an
+    abbreviations glossary) must not be duplicated into every fragment.
+    """
+    # An abbreviations file like the one users auto-append globally. The second
+    # entry has a backslash in the key, which `abbr` cannot strip, so it would
+    # leak verbatim into the output if auto_append were applied to fragments.
+    abbr_file = tmp_path / "abbreviations.md"
+    abbr_file.write_text("*[HTML]: Hyper Text Markup Language\n*[C\\C++]: C family languages\n")
+
+    mock_config["markdown_extensions"] = ["abbr", "pymdownx.snippets"]
+    mock_config["mdx_configs"] = {
+        "pymdownx.snippets": {
+            "auto_append": [str(abbr_file)],
+            "base_path": [str(tmp_path)],
+        }
+    }
+
+    markdown = """
+<quiz>
+A new quiz
+- [ ] Answer A
+- [x] Answer B
+
+The correct answer is B
+</quiz>
+"""
+    result = plugin.on_page_markdown(markdown, mock_page, mock_config)
+    html_result = plugin.on_page_content(
+        result, page=mock_page, config=mock_config, files=mock_files
+    )
+    assert html_result is not None
+
+    # The quiz itself renders correctly
+    assert "A new quiz" in html_result
+    assert "Answer A" in html_result
+    assert "Answer B" in html_result
+
+    # The auto-appended abbreviation definitions must NOT leak into the output
+    assert "C family languages" not in html_result
+    assert "*[C" not in html_result
+    # No stray backslash from the unparseable abbreviation definition
+    assert "\\" not in strip_injected_assets(html_result)
+
+
 def test_default_extensions_when_config_empty(
     plugin: MkDocsQuizPlugin, mock_page: Page, mock_files: Files
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes a regression where `pymdownx.snippets` `auto_append` configuration was injecting file content (e.g., abbreviations glossaries) into every quiz fragment, causing duplicated and malformed content in quiz questions and answers.

## Changes

- **Plugin fix** (`mkdocs_quiz/plugin.py`):
  - Modified `_create_fragment_markdown()` to strip `auto_append` from `pymdownx.snippets` configuration when creating Markdown instances for quiz fragment conversion
  - Creates a filtered copy of extension configs without mutating the shared `config.mdx_configs`
  - Preserves all other snippet extension settings while preventing auto-append injection into individual quiz parts

- **Test coverage** (`tests/test_plugin.py`):
  - Added regression test `test_snippets_auto_append_not_injected_into_fragments()` that verifies:
    - Quiz content renders correctly with snippets extension enabled
    - Auto-appended abbreviation definitions don't leak into quiz output
    - Malformed abbreviation syntax (with backslashes) doesn't appear in rendered HTML

- **Documentation** (`CHANGELOG.md`):
  - Added entry documenting the bug fix for issue #56

## Implementation Details

The fix addresses the root cause: each quiz part (question, answers, content) is converted as its own fragment using a separate Markdown instance. The `pymdownx.snippets` extension's `auto_append` feature injects configured files into every document processed, which was duplicating content and causing raw syntax to leak when the appended file contained unparseable content (e.g., abbreviation definitions with special characters).

The solution creates a filtered extension config that removes only the `auto_append` key while preserving other snippet settings, ensuring fragments are processed without unwanted injection while maintaining full functionality for the main page markdown conversion.

https://claude.ai/code/session_0115N9HEmTwfefjACZN4UiLs